### PR TITLE
feat: implement ability system with HUD

### DIFF
--- a/src/app/core/abilityHud.ts
+++ b/src/app/core/abilityHud.ts
@@ -1,0 +1,74 @@
+export interface AbilityStatus {
+  id: string;
+  slot: number;
+  hotkey: number;
+  cooldown: number;
+  remainingCooldown: number;
+}
+
+interface AbilitySlotElements {
+  cooldownOverlay: HTMLDivElement;
+  cooldownText: HTMLSpanElement;
+  keyLabel: HTMLSpanElement;
+}
+
+export class AbilityHud {
+  private readonly container: HTMLDivElement;
+  private readonly slots = new Map<number, AbilitySlotElements>();
+
+  constructor(private readonly host: HTMLElement, abilities: AbilityStatus[]) {
+    this.container = document.createElement("div");
+    this.container.className = "ability-bar";
+
+    const sorted = [...abilities].sort((a, b) => a.slot - b.slot);
+    for (const ability of sorted) {
+      const slot = document.createElement("div");
+      slot.className = "ability-slot";
+
+      const keyLabel = document.createElement("span");
+      keyLabel.className = "ability-slot__label";
+      keyLabel.textContent = ability.hotkey.toString();
+      slot.appendChild(keyLabel);
+
+      const cooldownOverlay = document.createElement("div");
+      cooldownOverlay.className = "ability-slot__cooldown";
+      cooldownOverlay.style.display = "none";
+
+      const cooldownText = document.createElement("span");
+      cooldownOverlay.appendChild(cooldownText);
+      slot.appendChild(cooldownOverlay);
+
+      this.slots.set(ability.slot, {
+        cooldownOverlay,
+        cooldownText,
+        keyLabel
+      });
+
+      this.container.appendChild(slot);
+    }
+
+    this.host.appendChild(this.container);
+  }
+
+  update(statuses: AbilityStatus[]) {
+    for (const status of statuses) {
+      const slot = this.slots.get(status.slot);
+      if (!slot) continue;
+
+      slot.keyLabel.textContent = status.hotkey.toString();
+
+      if (status.remainingCooldown > 0) {
+        slot.cooldownOverlay.style.display = "flex";
+        slot.cooldownText.textContent = status.remainingCooldown.toFixed(1);
+      } else {
+        slot.cooldownOverlay.style.display = "none";
+        slot.cooldownText.textContent = "";
+      }
+    }
+  }
+
+  dispose() {
+    this.container.remove();
+    this.slots.clear();
+  }
+}

--- a/src/app/core/classes/marksman.ts
+++ b/src/app/core/classes/marksman.ts
@@ -10,16 +10,77 @@ export interface MarksmanOptions {
   projectileSpeed?: number;
 }
 
+interface AbilityDefinition {
+  id: string;
+  hotkey: number;
+  cooldown: number;
+  execute: (context: MarksmanContext) => void;
+}
+
+interface AbilityState {
+  definition: AbilityDefinition;
+  remainingCooldown: number;
+}
+
+export interface MarksmanAbilityStatus {
+  id: string;
+  slot: number;
+  hotkey: number;
+  cooldown: number;
+  remainingCooldown: number;
+}
+
 export class Marksman {
   private readonly projectileSpeed: number;
   private readonly direction = new Vector3();
   private readonly origin = new Vector3();
+  private readonly abilities: AbilityState[];
 
   constructor(options?: MarksmanOptions) {
     this.projectileSpeed = options?.projectileSpeed ?? 14;
+    this.abilities = Array.from({ length: 4 }, (_, index) => ({
+      definition: {
+        id: `marksman-shot-${index + 1}`,
+        hotkey: index + 1,
+        cooldown: 4,
+        execute: (context: MarksmanContext) => {
+          this.fire(context);
+        }
+      },
+      remainingCooldown: 0
+    }));
   }
 
-  tryFire(context: MarksmanContext) {
+  update(deltaTime: number) {
+    for (const ability of this.abilities) {
+      if (ability.remainingCooldown > 0) {
+        ability.remainingCooldown = Math.max(ability.remainingCooldown - deltaTime, 0);
+      }
+    }
+  }
+
+  tryUseAbility(slot: number, context: MarksmanContext): boolean {
+    const ability = this.abilities[slot];
+    if (!ability || ability.remainingCooldown > 0) {
+      return false;
+    }
+
+    ability.definition.execute(context);
+    ability.remainingCooldown = ability.definition.cooldown;
+    return true;
+  }
+
+  getAbilityStatuses(): MarksmanAbilityStatus[] {
+    return this.abilities.map((ability, index) => ({
+      id: ability.definition.id,
+      slot: index,
+      hotkey: ability.definition.hotkey,
+      cooldown: ability.definition.cooldown,
+      remainingCooldown: ability.remainingCooldown
+    }));
+  }
+
+  private fire(context: MarksmanContext) {
     this.direction.copy(context.enemyPosition).sub(context.playerPosition);
     if (this.direction.lengthSq() === 0) {
       return;

--- a/src/app/input/keyboard.ts
+++ b/src/app/input/keyboard.ts
@@ -4,6 +4,9 @@ export type MovementInput = {
   left: boolean;
   right: boolean;
   ability1: boolean;
+  ability2: boolean;
+  ability3: boolean;
+  ability4: boolean;
 };
 
 const DEFAULT_INPUT: MovementInput = {
@@ -11,7 +14,10 @@ const DEFAULT_INPUT: MovementInput = {
   down: false,
   left: false,
   right: false,
-  ability1: false
+  ability1: false,
+  ability2: false,
+  ability3: false,
+  ability4: false
 };
 
 export class KeyboardController {
@@ -30,6 +36,9 @@ export class KeyboardController {
   snapshot(): MovementInput {
     const snapshot = { ...this.state };
     this.state.ability1 = false;
+    this.state.ability2 = false;
+    this.state.ability3 = false;
+    this.state.ability4 = false;
     return snapshot;
   }
 
@@ -63,6 +72,21 @@ export class KeyboardController {
       case "Digit1":
         if (pressed) {
           this.state.ability1 = true;
+        }
+        break;
+      case "Digit2":
+        if (pressed) {
+          this.state.ability2 = true;
+        }
+        break;
+      case "Digit3":
+        if (pressed) {
+          this.state.ability3 = true;
+        }
+        break;
+      case "Digit4":
+        if (pressed) {
+          this.state.ability4 = true;
         }
         break;
       default:

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -26,3 +26,53 @@ canvas {
   flex: 1;
   display: block;
 }
+
+.ability-bar {
+  position: absolute;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 12px;
+  padding: 8px 12px;
+  background: rgba(15, 23, 42, 0.4);
+  border-radius: 12px;
+  backdrop-filter: blur(8px);
+  pointer-events: none;
+}
+
+.ability-slot {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  border: 2px solid rgba(148, 163, 184, 0.7);
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #f8fafc;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  background: rgba(30, 41, 59, 0.55);
+  overflow: hidden;
+}
+
+.ability-slot__label {
+  position: absolute;
+  bottom: 6px;
+  right: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  opacity: 0.7;
+}
+
+.ability-slot__cooldown {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: 700;
+  background: rgba(15, 23, 42, 0.65);
+}


### PR DESCRIPTION
## Summary
- add four-slot ability configuration and cooldown tracking to the marksman class
- expand keyboard input to fire mapped hotkeys and wire ability usage through the game loop
- render a bottom HUD that shows ability slots and remaining cooldowns

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e36508e7f483259d4ca47d9ead45ed