### PR TITLE
feat: add marksman class gauge

### DIFF
--- a/src/app/core/abilityHud.ts
+++ b/src/app/core/abilityHud.ts
@@ -6,6 +6,18 @@ export interface AbilityStatus {
   remainingCooldown: number;
 }
 
+export type ClassGaugeState =
+  | {
+      type: "bar";
+      current: number;
+      max: number;
+    };
+
+export interface AbilityHudState {
+  abilities: AbilityStatus[];
+  gauge?: ClassGaugeState;
+}
+
 interface AbilitySlotElements {
   cooldownOverlay: HTMLDivElement;
   cooldownText: HTMLSpanElement;
@@ -13,14 +25,34 @@ interface AbilitySlotElements {
 }
 
 export class AbilityHud {
+  private readonly root: HTMLDivElement;
+  private readonly gaugeContainer: HTMLDivElement;
+  private readonly gaugeTrack: HTMLDivElement;
+  private readonly gaugeFill: HTMLDivElement;
   private readonly container: HTMLDivElement;
   private readonly slots = new Map<number, AbilitySlotElements>();
 
-  constructor(private readonly host: HTMLElement, abilities: AbilityStatus[]) {
+  constructor(private readonly host: HTMLElement, state: AbilityHudState) {
+    this.root = document.createElement("div");
+    this.root.className = "ability-hud";
+
+    this.gaugeContainer = document.createElement("div");
+    this.gaugeContainer.className = "class-gauge";
+
+    this.gaugeTrack = document.createElement("div");
+    this.gaugeTrack.className = "class-gauge__track";
+
+    this.gaugeFill = document.createElement("div");
+    this.gaugeFill.className = "class-gauge__fill";
+    this.gaugeTrack.appendChild(this.gaugeFill);
+    this.gaugeContainer.appendChild(this.gaugeTrack);
+
+    this.root.appendChild(this.gaugeContainer);
+
     this.container = document.createElement("div");
     this.container.className = "ability-bar";
 
-    const sorted = [...abilities].sort((a, b) => a.slot - b.slot);
+    const sorted = [...state.abilities].sort((a, b) => a.slot - b.slot);
     for (const ability of sorted) {
       const slot = document.createElement("div");
       slot.className = "ability-slot";
@@ -47,11 +79,14 @@ export class AbilityHud {
       this.container.appendChild(slot);
     }
 
-    this.host.appendChild(this.container);
+    this.root.appendChild(this.container);
+    this.host.appendChild(this.root);
+
+    this.updateGauge(state.gauge);
   }
 
-  update(statuses: AbilityStatus[]) {
-    for (const status of statuses) {
+  update(state: AbilityHudState) {
+    for (const status of state.abilities) {
       const slot = this.slots.get(status.slot);
       if (!slot) continue;
 
@@ -65,10 +100,32 @@ export class AbilityHud {
         slot.cooldownText.textContent = "";
       }
     }
+
+    this.updateGauge(state.gauge);
   }
 
   dispose() {
-    this.container.remove();
+    this.root.remove();
     this.slots.clear();
+  }
+
+  private updateGauge(gauge: ClassGaugeState | undefined) {
+    if (!gauge) {
+      this.gaugeContainer.style.visibility = "hidden";
+      this.gaugeFill.style.width = "0%";
+      return;
+    }
+
+    this.gaugeContainer.style.visibility = "visible";
+
+    if (gauge.type === "bar") {
+      const ratio = gauge.max === 0 ? 0 : Math.min(Math.max(gauge.current / gauge.max, 0), 1);
+      this.gaugeTrack.style.display = "block";
+      this.gaugeFill.style.width = `${ratio * 100}%`;
+      return;
+    }
+
+    this.gaugeTrack.style.display = "none";
+    this.gaugeFill.style.width = "0%";
   }
 }

--- a/src/app/core/classes/marksman.ts
+++ b/src/app/core/classes/marksman.ts
@@ -1,20 +1,28 @@
 import { Vector3 } from "three";
 
+export interface ProjectileSpawnOptions {
+  scale?: number;
+}
+
 export interface MarksmanContext {
   playerPosition: Vector3;
   enemyPosition: Vector3;
-  spawnProjectile: (origin: Vector3, velocity: Vector3) => void;
+  spawnProjectile: (origin: Vector3, velocity: Vector3, options?: ProjectileSpawnOptions) => void;
 }
 
 export interface MarksmanOptions {
   projectileSpeed?: number;
 }
 
+interface AbilityExecutionContext {
+  empowered: boolean;
+}
+
 interface AbilityDefinition {
   id: string;
   hotkey: number;
   cooldown: number;
-  execute: (context: MarksmanContext) => void;
+  execute: (context: MarksmanContext, abilityContext: AbilityExecutionContext) => void;
 }
 
 interface AbilityState {
@@ -30,11 +38,19 @@ export interface MarksmanAbilityStatus {
   remainingCooldown: number;
 }
 
+export interface MarksmanGaugeStatus {
+  current: number;
+  max: number;
+}
+
 export class Marksman {
   private readonly projectileSpeed: number;
   private readonly direction = new Vector3();
   private readonly origin = new Vector3();
   private readonly abilities: AbilityState[];
+  private readonly maxGauge = 100;
+  private readonly gaugeGainPerUse = 10;
+  private gauge = 0;
 
   constructor(options?: MarksmanOptions) {
     this.projectileSpeed = options?.projectileSpeed ?? 14;
@@ -43,8 +59,8 @@ export class Marksman {
         id: `marksman-shot-${index + 1}`,
         hotkey: index + 1,
         cooldown: 4,
-        execute: (context: MarksmanContext) => {
-          this.fire(context);
+        execute: (context: MarksmanContext, abilityContext: AbilityExecutionContext) => {
+          this.fire(context, abilityContext.empowered);
         }
       },
       remainingCooldown: 0
@@ -65,8 +81,17 @@ export class Marksman {
       return false;
     }
 
-    ability.definition.execute(context);
+    const empowered = this.gauge >= this.maxGauge;
+
+    ability.definition.execute(context, { empowered });
     ability.remainingCooldown = ability.definition.cooldown;
+
+    if (empowered) {
+      this.gauge = 0;
+    } else {
+      this.gauge = Math.min(this.gauge + this.gaugeGainPerUse, this.maxGauge);
+    }
+
     return true;
   }
 
@@ -80,7 +105,11 @@ export class Marksman {
     }));
   }
 
-  private fire(context: MarksmanContext) {
+  getGaugeStatus(): MarksmanGaugeStatus {
+    return { current: this.gauge, max: this.maxGauge };
+  }
+
+  private fire(context: MarksmanContext, empowered: boolean) {
     this.direction.copy(context.enemyPosition).sub(context.playerPosition);
     if (this.direction.lengthSq() === 0) {
       return;
@@ -90,6 +119,6 @@ export class Marksman {
     this.origin.copy(context.playerPosition).addScaledVector(this.direction, 0.6);
 
     const velocity = this.direction.clone().multiplyScalar(this.projectileSpeed);
-    context.spawnProjectile(this.origin, velocity);
+    context.spawnProjectile(this.origin, velocity, { scale: empowered ? 3 : 1 });
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,11 +27,45 @@ canvas {
   display: block;
 }
 
-.ability-bar {
+.ability-hud {
   position: absolute;
   left: 50%;
   bottom: 24px;
   transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  pointer-events: none;
+}
+
+.class-gauge {
+  min-width: 284px;
+  display: flex;
+  justify-content: center;
+  padding: 0 8px;
+  visibility: hidden;
+}
+
+.class-gauge__track {
+  width: 100%;
+  max-width: 320px;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.25);
+  overflow: hidden;
+  position: relative;
+}
+
+.class-gauge__fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  background: linear-gradient(90deg, #38bdf8, #22d3ee);
+  transition: width 0.2s ease-out;
+}
+
+.ability-bar {
   display: flex;
   gap: 12px;
   padding: 8px 12px;


### PR DESCRIPTION
## Summary
- add a marksman gauge that increases with ability usage and resets after empowered shots
- render the class gauge above the hotkey bar and refactor the HUD layout for future gauge types
- scale empowered projectiles when the gauge is full to visibly distinguish the enhanced attack

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e368d7de408325aa35cfa57bf81878