### PR TITLE
feat: add black mage class with class switching

### DIFF
--- a/src/app/core/abilityHud.ts
+++ b/src/app/core/abilityHud.ts
@@ -11,6 +11,11 @@ export type ClassGaugeState =
       type: "bar";
       current: number;
       max: number;
+    }
+  | {
+      type: "charges";
+      current: number;
+      max: number;
     };
 
 export interface AbilityHudState {
@@ -29,6 +34,8 @@ export class AbilityHud {
   private readonly gaugeContainer: HTMLDivElement;
   private readonly gaugeTrack: HTMLDivElement;
   private readonly gaugeFill: HTMLDivElement;
+  private readonly gaugeCharges: HTMLDivElement;
+  private readonly gaugeChargeItems: HTMLDivElement[] = [];
   private readonly container: HTMLDivElement;
   private readonly slots = new Map<number, AbilitySlotElements>();
 
@@ -46,6 +53,10 @@ export class AbilityHud {
     this.gaugeFill.className = "class-gauge__fill";
     this.gaugeTrack.appendChild(this.gaugeFill);
     this.gaugeContainer.appendChild(this.gaugeTrack);
+
+    this.gaugeCharges = document.createElement("div");
+    this.gaugeCharges.className = "class-gauge__charges";
+    this.gaugeContainer.appendChild(this.gaugeCharges);
 
     this.root.appendChild(this.gaugeContainer);
 
@@ -113,6 +124,7 @@ export class AbilityHud {
     if (!gauge) {
       this.gaugeContainer.style.visibility = "hidden";
       this.gaugeFill.style.width = "0%";
+      this.gaugeCharges.style.display = "none";
       return;
     }
 
@@ -122,10 +134,43 @@ export class AbilityHud {
       const ratio = gauge.max === 0 ? 0 : Math.min(Math.max(gauge.current / gauge.max, 0), 1);
       this.gaugeTrack.style.display = "block";
       this.gaugeFill.style.width = `${ratio * 100}%`;
+      this.gaugeCharges.style.display = "none";
+      return;
+    }
+
+    if (gauge.type === "charges") {
+      this.gaugeTrack.style.display = "none";
+      this.gaugeFill.style.width = "0%";
+      this.updateGaugeCharges(gauge.max, gauge.current);
       return;
     }
 
     this.gaugeTrack.style.display = "none";
     this.gaugeFill.style.width = "0%";
+    this.gaugeCharges.style.display = "none";
+  }
+
+  private updateGaugeCharges(max: number, current: number) {
+    this.gaugeCharges.style.display = "flex";
+
+    if (this.gaugeChargeItems.length !== max) {
+      this.gaugeCharges.replaceChildren();
+      this.gaugeChargeItems.length = 0;
+
+      for (let i = 0; i < max; i += 1) {
+        const charge = document.createElement("div");
+        charge.className = "class-gauge__charge";
+        this.gaugeCharges.appendChild(charge);
+        this.gaugeChargeItems.push(charge);
+      }
+    }
+
+    this.gaugeChargeItems.forEach((charge, index) => {
+      if (index < current) {
+        charge.classList.add("class-gauge__charge--active");
+      } else {
+        charge.classList.remove("class-gauge__charge--active");
+      }
+    });
   }
 }

--- a/src/app/core/classes/abilities.ts
+++ b/src/app/core/classes/abilities.ts
@@ -1,0 +1,17 @@
+import type { PlayerClassContext } from "@app/core/classes/playerClass";
+
+export interface AbilityExecutionContext {
+  empowered?: boolean;
+}
+
+export interface ClassAbilityDefinition {
+  id: string;
+  hotkey: number;
+  cooldown: number;
+  execute: (context: PlayerClassContext, abilityContext?: AbilityExecutionContext) => void;
+}
+
+export interface ClassAbilityState {
+  definition: ClassAbilityDefinition;
+  remainingCooldown: number;
+}

--- a/src/app/core/classes/blackMage.ts
+++ b/src/app/core/classes/blackMage.ts
@@ -1,0 +1,174 @@
+import { Vector3 } from "three";
+import type { AbilityStatus } from "@app/core/abilityHud";
+import type { ClassAbilityDefinition, ClassAbilityState } from "@app/core/classes/abilities";
+import { createPlaceholderAbilityDefinition } from "@app/core/classes/placeholderAbility";
+import type { PlayerClass, PlayerClassContext } from "@app/core/classes/playerClass";
+
+const DARK_BOLT_CAST_TIME = 2;
+const DARK_BOLT_INSTANT_COOLDOWN = 2;
+const FLOW_STATE_COOLDOWN = 10;
+const MAX_FLOW_STATE_CHARGES = 3;
+const DARK_BOLT_PROJECTILE_SPEED = 12;
+
+export class BlackMage implements PlayerClass {
+  private readonly direction = new Vector3();
+  private readonly origin = new Vector3();
+  private readonly abilities: ClassAbilityState[];
+  private isCasting = false;
+  private castElapsed = 0;
+  private charges = 0;
+
+  constructor() {
+    this.abilities = [
+      { definition: this.createDarkBoltDefinition(), remainingCooldown: 0 },
+      { definition: this.createFlowStateDefinition(), remainingCooldown: 0 },
+      {
+        definition: createPlaceholderAbilityDefinition("black-mage-placeholder-3", 3),
+        remainingCooldown: 0
+      },
+      {
+        definition: createPlaceholderAbilityDefinition("black-mage-placeholder-4", 4),
+        remainingCooldown: 0
+      }
+    ];
+  }
+
+  update(deltaTime: number, context: PlayerClassContext) {
+    for (const ability of this.abilities) {
+      if (ability.remainingCooldown > 0) {
+        ability.remainingCooldown = Math.max(ability.remainingCooldown - deltaTime, 0);
+      }
+    }
+
+    if (!this.isCasting) {
+      return;
+    }
+
+    if (context.isPlayerMoving) {
+      this.cancelCast(context);
+      return;
+    }
+
+    this.castElapsed += deltaTime;
+    const progress = Math.min(this.castElapsed / DARK_BOLT_CAST_TIME, 1);
+    context.setCastProgress(progress);
+
+    if (this.castElapsed >= DARK_BOLT_CAST_TIME) {
+      this.completeCast(context);
+    }
+  }
+
+  tryUseAbility(slot: number, context: PlayerClassContext): boolean {
+    const ability = this.abilities[slot];
+    if (!ability) {
+      return false;
+    }
+
+    if (slot === 0) {
+      return this.tryUseDarkBolt(ability, context);
+    }
+
+    if (ability.remainingCooldown > 0) {
+      return false;
+    }
+
+    if (slot === 1) {
+      this.activateFlowState();
+      ability.remainingCooldown = ability.definition.cooldown;
+      return true;
+    }
+
+    ability.definition.execute(context);
+    ability.remainingCooldown = ability.definition.cooldown;
+    return true;
+  }
+
+  getAbilityStatuses(): AbilityStatus[] {
+    return this.abilities.map((ability, index) => ({
+      id: ability.definition.id,
+      slot: index,
+      hotkey: ability.definition.hotkey,
+      cooldown: ability.definition.cooldown,
+      remainingCooldown: ability.remainingCooldown
+    }));
+  }
+
+  getGaugeState() {
+    return {
+      type: "charges" as const,
+      current: this.charges,
+      max: MAX_FLOW_STATE_CHARGES
+    };
+  }
+
+  private tryUseDarkBolt(ability: ClassAbilityState, context: PlayerClassContext): boolean {
+    if (ability.remainingCooldown > 0 || this.isCasting) {
+      return false;
+    }
+
+    if (this.charges > 0) {
+      this.charges -= 1;
+      ability.remainingCooldown = ability.definition.cooldown;
+      this.fireDarkBolt(context);
+      return true;
+    }
+
+    this.isCasting = true;
+    this.castElapsed = 0;
+    context.setCastProgress(0);
+    return true;
+  }
+
+  private cancelCast(context: PlayerClassContext) {
+    this.isCasting = false;
+    this.castElapsed = 0;
+    context.setCastProgress(null);
+  }
+
+  private completeCast(context: PlayerClassContext) {
+    this.isCasting = false;
+    this.castElapsed = 0;
+    context.setCastProgress(null);
+    this.fireDarkBolt(context);
+  }
+
+  private activateFlowState() {
+    this.charges = MAX_FLOW_STATE_CHARGES;
+  }
+
+  private fireDarkBolt(context: PlayerClassContext) {
+    const ability = this.abilities[0];
+    ability.definition.execute(context);
+  }
+
+  private createDarkBoltDefinition(): ClassAbilityDefinition {
+    return {
+      id: "black-mage-dark-bolt",
+      hotkey: 1,
+      cooldown: DARK_BOLT_INSTANT_COOLDOWN,
+      execute: (context: PlayerClassContext) => {
+        this.direction.copy(context.enemyPosition).sub(context.playerPosition);
+        if (this.direction.lengthSq() === 0) {
+          return;
+        }
+
+        this.direction.normalize();
+        this.origin.copy(context.playerPosition).addScaledVector(this.direction, 0.6);
+
+        const velocity = this.direction.clone().multiplyScalar(DARK_BOLT_PROJECTILE_SPEED);
+        context.spawnProjectile(this.origin, velocity, { color: 0x111827 });
+      }
+    };
+  }
+
+  private createFlowStateDefinition(): ClassAbilityDefinition {
+    return {
+      id: "black-mage-flow-state",
+      hotkey: 2,
+      cooldown: FLOW_STATE_COOLDOWN,
+      execute: () => {
+        // Flow State effect handled in tryUseAbility
+      }
+    };
+  }
+}

--- a/src/app/core/classes/placeholderAbility.ts
+++ b/src/app/core/classes/placeholderAbility.ts
@@ -1,0 +1,12 @@
+import type { ClassAbilityDefinition } from "@app/core/classes/abilities";
+
+export function createPlaceholderAbilityDefinition(id: string, hotkey: number): ClassAbilityDefinition {
+  return {
+    id,
+    hotkey,
+    cooldown: 5,
+    execute: () => {
+      // Intentionally empty placeholder ability.
+    }
+  };
+}

--- a/src/app/core/classes/playerClass.ts
+++ b/src/app/core/classes/playerClass.ts
@@ -1,0 +1,22 @@
+import type { Vector3 } from "three";
+import type { AbilityStatus, ClassGaugeState } from "@app/core/abilityHud";
+
+export interface ProjectileSpawnOptions {
+  scale?: number;
+  color?: number;
+}
+
+export interface PlayerClassContext {
+  playerPosition: Vector3;
+  enemyPosition: Vector3;
+  isPlayerMoving: boolean;
+  spawnProjectile: (origin: Vector3, velocity: Vector3, options?: ProjectileSpawnOptions) => void;
+  setCastProgress: (progress: number | null) => void;
+}
+
+export interface PlayerClass {
+  update(deltaTime: number, context: PlayerClassContext): void;
+  tryUseAbility(slot: number, context: PlayerClassContext): boolean;
+  getAbilityStatuses(): AbilityStatus[];
+  getGaugeState(): ClassGaugeState | undefined;
+}

--- a/src/app/core/game.ts
+++ b/src/app/core/game.ts
@@ -20,8 +20,9 @@ import { MovementSystem } from "@app/entities/systems/movementSystem";
 import { TelegraphSystem } from "@app/entities/systems/telegraphSystem";
 import { CollisionSystem } from "@app/entities/systems/collisionSystem";
 import { PlayerBlueprint } from "@app/entities/examples/entityShowcase";
+import { BlackMage } from "@app/core/classes/blackMage";
 import { Marksman } from "@app/core/classes/marksman";
-import type { MarksmanGaugeStatus, ProjectileSpawnOptions } from "@app/core/classes/marksman";
+import type { PlayerClass, PlayerClassContext, ProjectileSpawnOptions } from "@app/core/classes/playerClass";
 import { AbilityHud } from "@app/core/abilityHud";
 import type { AbilityHudState } from "@app/core/abilityHud";
 
@@ -30,7 +31,15 @@ interface ProjectileInstance {
   position: Vector3;
   velocity: Vector3;
   lifetime: number;
+  material?: MeshBasicMaterial;
 }
+
+type ClassId = "marksman" | "blackMage";
+
+const CLASS_OPTIONS: { id: ClassId; label: string }[] = [
+  { id: "marksman", label: "Marksman" },
+  { id: "blackMage", label: "Black Mage" }
+];
 
 export interface GameStatsListener {
   (stats: { fps: number; rawDelta: number }): void;
@@ -43,7 +52,10 @@ export class ShatterGame {
   private readonly encounter = DEFAULT_ENCOUNTER;
   private readonly player: PlayerToken;
   private readonly boss = this.encounter.boss.create();
-  private readonly marksman = new Marksman();
+  private readonly classFactories: Record<ClassId, () => PlayerClass> = {
+    marksman: () => new Marksman(),
+    blackMage: () => new BlackMage()
+  };
   private readonly direction = new Vector3();
   private readonly playerPosition = new Vector3();
   private readonly spawnPosition = new Vector3(-5, 0, 0);
@@ -59,6 +71,9 @@ export class ShatterGame {
   private readonly playerEntity: Entity;
   private readonly playerTransform: TransformComponent;
   private readonly playerMotion: MotionComponent;
+  private currentClassId: ClassId = "marksman";
+  private playerClass: PlayerClass;
+  private classContext!: PlayerClassContext;
   private statsListener: GameStatsListener | null = null;
 
   constructor(private readonly canvas: HTMLCanvasElement, private readonly host: HTMLElement) {
@@ -84,11 +99,26 @@ export class ShatterGame {
     this.player.teleport(this.spawnPosition);
     this.playerPosition.copy(this.spawnPosition);
 
+    this.playerClass = this.createClass(this.currentClassId);
+    this.classContext = {
+      playerPosition: this.playerPosition,
+      enemyPosition: this.bossPosition,
+      isPlayerMoving: false,
+      spawnProjectile: this.spawnProjectile,
+      setCastProgress: (progress) => this.player.setCastProgress(progress)
+    };
+
     this.loop = new GameLoop(this.update);
     this.loop.setStatsListener(this.handleLoopStats);
 
     this.overlay = new DebugOverlay(host);
     this.overlay.setVisible(false);
+
+    this.overlay.setClassOptions({
+      options: CLASS_OPTIONS,
+      current: this.currentClassId,
+      onSelect: this.handleClassSelected
+    });
 
     this.debugControls = new DebugControls({
       toggleOverlay: () => this.overlay.toggle(),
@@ -114,6 +144,7 @@ export class ShatterGame {
     this.debugControls.dispose();
     this.overlay.dispose();
     this.abilityHud.dispose();
+    this.player.setCastProgress(null);
     this.clearProjectiles();
     this.ctx.scene.remove(this.boss.mesh);
     this.projectileGeometry.dispose();
@@ -157,21 +188,18 @@ export class ShatterGame {
 
     this.world.update(deltaTime);
 
-    this.marksman.update(deltaTime);
-
     this.playerPosition.copy(this.playerTransform.position);
     this.enforceArenaBounds();
     this.player.teleport(this.playerPosition);
+
+    this.classContext.isPlayerMoving = this.playerMotion.velocity.lengthSq() > 0.0001;
+    this.playerClass.update(deltaTime, this.classContext);
 
     const abilityInputs = [input.ability1, input.ability2, input.ability3, input.ability4];
     abilityInputs.forEach((pressed, index) => {
       if (!pressed) return;
 
-      this.marksman.tryUseAbility(index, {
-        playerPosition: this.playerPosition,
-        enemyPosition: this.bossPosition,
-        spawnProjectile: this.spawnProjectile
-      });
+      this.playerClass.tryUseAbility(index, this.classContext);
     });
 
     this.abilityHud.update(this.getAbilityHudState());
@@ -216,6 +244,11 @@ export class ShatterGame {
     this.playerTransform.position.copy(this.spawnPosition);
     this.playerPosition.copy(this.spawnPosition);
     this.player.teleport(this.spawnPosition);
+    const previousMovement = this.classContext.isPlayerMoving;
+    this.classContext.isPlayerMoving = true;
+    this.playerClass.update(0, this.classContext);
+    this.classContext.isPlayerMoving = previousMovement;
+    this.player.setCastProgress(null);
     this.clearProjectiles();
     this.enforceArenaBounds();
   }
@@ -225,29 +258,23 @@ export class ShatterGame {
     velocity: Vector3,
     options?: ProjectileSpawnOptions
   ) => {
-    const mesh = new Mesh(this.projectileGeometry, this.projectileMaterial);
+    const material = options?.color
+      ? new MeshBasicMaterial({ color: options.color })
+      : this.projectileMaterial;
+    const mesh = new Mesh(this.projectileGeometry, material);
     const position = new Vector3(origin.x, 0.25, origin.z);
     const direction = new Vector3().copy(velocity);
     direction.y = 0;
     mesh.position.set(position.x, position.y, position.z);
     mesh.scale.setScalar(options?.scale ?? 1);
     this.ctx.scene.add(mesh);
-    this.projectiles.push({ mesh, position, velocity: direction, lifetime: 2 });
+    this.projectiles.push({ mesh, position, velocity: direction, lifetime: 2, material: options?.color ? material : undefined });
   };
 
   private getAbilityHudState(): AbilityHudState {
-    const gauge = this.marksman.getGaugeStatus();
     return {
-      abilities: this.marksman.getAbilityStatuses(),
-      gauge: this.mapGaugeStatus(gauge)
-    };
-  }
-
-  private mapGaugeStatus(gauge: MarksmanGaugeStatus): AbilityHudState["gauge"] {
-    return {
-      type: "bar",
-      current: gauge.current,
-      max: gauge.max
+      abilities: this.playerClass.getAbilityStatuses(),
+      gauge: this.playerClass.getGaugeState()
     };
   }
 
@@ -270,14 +297,34 @@ export class ShatterGame {
     }
   }
 
+  private createClass(id: ClassId): PlayerClass {
+    const factory = this.classFactories[id];
+    return factory();
+  }
+
+  private readonly handleClassSelected = (id: ClassId) => {
+    if (this.currentClassId === id) {
+      return;
+    }
+
+    this.currentClassId = id;
+    this.playerClass = this.createClass(id);
+    this.classContext.isPlayerMoving = false;
+    this.player.setCastProgress(null);
+    this.overlay.setCurrentClass(id);
+    this.abilityHud.update(this.getAbilityHudState());
+  };
+
   private removeProjectile(index: number) {
     const [projectile] = this.projectiles.splice(index, 1);
     this.ctx.scene.remove(projectile.mesh);
+    projectile.material?.dispose();
   }
 
   private clearProjectiles() {
     for (const projectile of this.projectiles) {
       this.ctx.scene.remove(projectile.mesh);
+      projectile.material?.dispose();
     }
     this.projectiles.length = 0;
   }

--- a/src/app/core/game.ts
+++ b/src/app/core/game.ts
@@ -36,6 +36,9 @@ interface ProjectileInstance {
 
 type ClassId = "marksman" | "blackMage";
 
+// Allow a small amount of residual velocity while still counting the player as idle for casting.
+const PLAYER_MOVEMENT_IDLE_THRESHOLD_SQ = 0.1 * 0.1;
+
 const CLASS_OPTIONS: { id: ClassId; label: string }[] = [
   { id: "marksman", label: "Marksman" },
   { id: "blackMage", label: "Black Mage" }
@@ -192,7 +195,8 @@ export class ShatterGame {
     this.enforceArenaBounds();
     this.player.teleport(this.playerPosition);
 
-    this.classContext.isPlayerMoving = this.playerMotion.velocity.lengthSq() > 0.0001;
+    this.classContext.isPlayerMoving =
+      this.playerMotion.velocity.lengthSq() > PLAYER_MOVEMENT_IDLE_THRESHOLD_SQ;
     this.playerClass.update(deltaTime, this.classContext);
 
     const abilityInputs = [input.ability1, input.ability2, input.ability3, input.ability4];

--- a/src/app/debug/debugOverlay.ts
+++ b/src/app/debug/debugOverlay.ts
@@ -1,8 +1,19 @@
-﻿interface DebugOverlayStats {
+interface DebugOverlayStats {
   fps: number;
   deltaMs: number;
   position: { x: number; z: number };
   speed: number;
+}
+
+interface DebugOverlayClassOption {
+  id: string;
+  label: string;
+}
+
+interface DebugOverlayClassSelection {
+  options: DebugOverlayClassOption[];
+  current: string;
+  onSelect: (id: string) => void;
 }
 
 export class DebugOverlay {
@@ -11,6 +22,11 @@ export class DebugOverlay {
   private readonly deltaEl: HTMLDivElement;
   private readonly positionEl: HTMLDivElement;
   private readonly speedEl: HTMLDivElement;
+  private readonly classContainer: HTMLDivElement;
+  private readonly classButtonsRow: HTMLDivElement;
+  private readonly classButtons = new Map<string, HTMLButtonElement>();
+  private classSelectionCallback: ((id: string) => void) | null = null;
+  private currentClassId: string | null = null;
   private visible = false;
 
   constructor(private readonly host: HTMLElement) {
@@ -22,11 +38,12 @@ export class DebugOverlay {
     this.root.style.background = "rgba(15, 23, 42, 0.85)";
     this.root.style.border = "1px solid rgba(148, 163, 184, 0.3)";
     this.root.style.borderRadius = "8px";
-    this.root.style.fontFamily = "ui-monospace, SFMono-Regular, SFMono, Consolas, Liberation Mono, Menlo, monospace";
+    this.root.style.fontFamily =
+      "ui-monospace, SFMono-Regular, SFMono, Consolas, Liberation Mono, Menlo, monospace";
     this.root.style.fontSize = "12px";
     this.root.style.lineHeight = "18px";
     this.root.style.color = "#f8fafc";
-    this.root.style.pointerEvents = "none";
+    this.root.style.pointerEvents = "auto";
     this.root.style.display = "none";
     this.root.style.zIndex = "100";
 
@@ -35,6 +52,24 @@ export class DebugOverlay {
     title.style.fontWeight = "600";
     title.style.marginBottom = "4px";
     this.root.appendChild(title);
+
+    this.classContainer = document.createElement("div");
+    this.classContainer.style.display = "none";
+    this.classContainer.style.marginBottom = "8px";
+    this.root.appendChild(this.classContainer);
+
+    const classLabel = document.createElement("div");
+    classLabel.textContent = "Class";
+    classLabel.style.fontWeight = "600";
+    classLabel.style.marginBottom = "4px";
+    this.classContainer.appendChild(classLabel);
+
+    this.classButtonsRow = document.createElement("div");
+    this.classButtonsRow.style.display = "flex";
+    this.classButtonsRow.style.flexWrap = "wrap";
+    this.classButtonsRow.style.gap = "6px";
+    this.classButtonsRow.style.pointerEvents = "auto";
+    this.classContainer.appendChild(this.classButtonsRow);
 
     this.fpsEl = this.createRow();
     this.deltaEl = this.createRow();
@@ -53,6 +88,57 @@ export class DebugOverlay {
     this.setVisible(!this.visible);
   }
 
+  setClassOptions(selection: DebugOverlayClassSelection) {
+    this.classButtons.clear();
+    this.classButtonsRow.replaceChildren();
+
+    if (selection.options.length === 0) {
+      this.classContainer.style.display = "none";
+      this.classSelectionCallback = null;
+      this.currentClassId = null;
+      return;
+    }
+
+    this.classSelectionCallback = selection.onSelect;
+    this.classContainer.style.display = "block";
+
+    for (const option of selection.options) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = option.label;
+      button.style.padding = "4px 8px";
+      button.style.borderRadius = "6px";
+      button.style.border = "1px solid rgba(148, 163, 184, 0.35)";
+      button.style.background = "rgba(30, 41, 59, 0.6)";
+      button.style.color = "#f8fafc";
+      button.style.fontSize = "11px";
+      button.style.fontWeight = "600";
+      button.style.cursor = "pointer";
+      button.style.transition = "background 0.2s ease-out, border-color 0.2s ease-out, opacity 0.2s ease-out";
+      button.addEventListener("click", () => {
+        if (this.classSelectionCallback) {
+          this.classSelectionCallback(option.id);
+        }
+      });
+      this.classButtonsRow.appendChild(button);
+      this.classButtons.set(option.id, button);
+    }
+
+    this.setCurrentClass(selection.current);
+  }
+
+  setCurrentClass(id: string) {
+    this.currentClassId = id;
+    for (const [optionId, button] of this.classButtons.entries()) {
+      const active = optionId === id;
+      button.disabled = active;
+      button.style.opacity = active ? "1" : "0.8";
+      button.style.background = active ? "rgba(56, 189, 248, 0.3)" : "rgba(30, 41, 59, 0.6)";
+      button.style.borderColor = active ? "rgba(56, 189, 248, 0.6)" : "rgba(148, 163, 184, 0.35)";
+      button.style.cursor = active ? "default" : "pointer";
+    }
+  }
+
   update(stats: DebugOverlayStats) {
     if (!this.visible) return;
     this.fpsEl.textContent = `FPS: ${stats.fps.toFixed(1)}`;
@@ -63,6 +149,7 @@ export class DebugOverlay {
 
   dispose() {
     this.host.removeChild(this.root);
+    this.classButtons.clear();
   }
 
   private createRow() {

--- a/src/app/rendering/playerToken.ts
+++ b/src/app/rendering/playerToken.ts
@@ -1,8 +1,18 @@
-﻿import { CircleGeometry, Group, Mesh, MeshBasicMaterial, Vector3 } from "three";
+import {
+  CircleGeometry,
+  DoubleSide,
+  Group,
+  Mesh,
+  MeshBasicMaterial,
+  RingGeometry,
+  Vector3
+} from "three";
 
 export class PlayerToken {
   readonly mesh: Group;
   private readonly position = new Vector3();
+  private readonly castProgressMesh: Mesh;
+  private currentCastProgress: number | null = null;
 
   constructor() {
     this.mesh = new Group();
@@ -13,6 +23,16 @@ export class PlayerToken {
     );
     body.rotation.x = -Math.PI / 2;
     this.mesh.add(body);
+
+    this.castProgressMesh = new Mesh(
+      new RingGeometry(0.58, 0.74, 64, 1, -Math.PI / 2, 0.001),
+      new MeshBasicMaterial({ color: 0x38bdf8, transparent: true, opacity: 0.55, side: DoubleSide })
+    );
+    this.castProgressMesh.rotation.x = -Math.PI / 2;
+    this.castProgressMesh.position.y = 0.03;
+    this.castProgressMesh.visible = false;
+    this.castProgressMesh.renderOrder = 1;
+    this.mesh.add(this.castProgressMesh);
 
     this.mesh.position.set(0, 0.02, 0);
   }
@@ -29,6 +49,27 @@ export class PlayerToken {
 
   getPosition(out: Vector3): Vector3 {
     return out.copy(this.position);
+  }
+
+  setCastProgress(progress: number | null) {
+    if (progress === null) {
+      this.currentCastProgress = null;
+      this.castProgressMesh.visible = false;
+      return;
+    }
+
+    const clamped = Math.min(Math.max(progress, 0), 1);
+
+    if (this.currentCastProgress === clamped && this.castProgressMesh.visible) {
+      return;
+    }
+
+    this.currentCastProgress = clamped;
+    this.castProgressMesh.visible = true;
+
+    const newGeometry = new RingGeometry(0.58, 0.74, 64, 1, -Math.PI / 2, Math.max(clamped, 0.001) * Math.PI * 2);
+    this.castProgressMesh.geometry.dispose();
+    this.castProgressMesh.geometry = newGeometry;
   }
 
   private syncMeshPosition() {

--- a/src/app/rendering/playerToken.ts
+++ b/src/app/rendering/playerToken.ts
@@ -8,6 +8,9 @@ import {
   Vector3
 } from "three";
 
+const CAST_PROGRESS_TOP_ANGLE = Math.PI / 2;
+const MIN_CAST_PROGRESS = 0.001;
+
 export class PlayerToken {
   readonly mesh: Group;
   private readonly position = new Vector3();
@@ -25,7 +28,7 @@ export class PlayerToken {
     this.mesh.add(body);
 
     this.castProgressMesh = new Mesh(
-      new RingGeometry(0.58, 0.74, 64, 1, -Math.PI / 2, 0.001),
+      new RingGeometry(0.58, 0.74, 64, 1, CAST_PROGRESS_TOP_ANGLE - MIN_CAST_PROGRESS, MIN_CAST_PROGRESS),
       new MeshBasicMaterial({ color: 0x38bdf8, transparent: true, opacity: 0.55, side: DoubleSide })
     );
     this.castProgressMesh.rotation.x = -Math.PI / 2;
@@ -67,7 +70,9 @@ export class PlayerToken {
     this.currentCastProgress = clamped;
     this.castProgressMesh.visible = true;
 
-    const newGeometry = new RingGeometry(0.58, 0.74, 64, 1, -Math.PI / 2, Math.max(clamped, 0.001) * Math.PI * 2);
+    const thetaLength = Math.max(clamped, MIN_CAST_PROGRESS) * Math.PI * 2;
+    const thetaStart = CAST_PROGRESS_TOP_ANGLE - thetaLength;
+    const newGeometry = new RingGeometry(0.58, 0.74, 64, 1, thetaStart, thetaLength);
     this.castProgressMesh.geometry.dispose();
     this.castProgressMesh.geometry = newGeometry;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -65,6 +65,27 @@ canvas {
   transition: width 0.2s ease-out;
 }
 
+.class-gauge__charges {
+  display: none;
+  gap: 8px;
+  align-items: center;
+}
+
+.class-gauge__charge {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  border: 2px solid rgba(148, 163, 184, 0.6);
+  background: rgba(30, 41, 59, 0.4);
+  box-shadow: inset 0 0 6px rgba(15, 23, 42, 0.6);
+  transition: background 0.2s ease-out, border-color 0.2s ease-out;
+}
+
+.class-gauge__charge--active {
+  border-color: rgba(56, 189, 248, 0.9);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.75), rgba(14, 116, 144, 0.9));
+}
+
 .ability-bar {
   display: flex;
   gap: 12px;


### PR DESCRIPTION
## Summary
- add a black mage class with Dark Bolt casting, Flow State charges, and shared placeholder abilities
- update the ability HUD and player token to support charge gauges and cast progress visuals
- enable switching between classes through the debug overlay and shared class interfaces

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4794cd69083259eba15f02543ac0d