### PR TITLE
feat: implement damage engine and debug tracker

### DIFF
--- a/src/app/core/classes/abilities.ts
+++ b/src/app/core/classes/abilities.ts
@@ -8,6 +8,7 @@ export interface ClassAbilityDefinition {
   id: string;
   hotkey: number;
   cooldown: number;
+  baseDamage?: number;
   execute: (context: PlayerClassContext, abilityContext?: AbilityExecutionContext) => void;
 }
 

--- a/src/app/core/classes/blackMage.ts
+++ b/src/app/core/classes/blackMage.ts
@@ -3,12 +3,14 @@ import type { AbilityStatus } from "@app/core/abilityHud";
 import type { ClassAbilityDefinition, ClassAbilityState } from "@app/core/classes/abilities";
 import { createPlaceholderAbilityDefinition } from "@app/core/classes/placeholderAbility";
 import type { PlayerClass, PlayerClassContext } from "@app/core/classes/playerClass";
+import type { DamageTag } from "@app/core/damage";
 
 const DARK_BOLT_CAST_TIME = 2;
 const DARK_BOLT_INSTANT_COOLDOWN = 2;
 const FLOW_STATE_COOLDOWN = 10;
 const MAX_FLOW_STATE_CHARGES = 3;
 const DARK_BOLT_PROJECTILE_SPEED = 12;
+const DARK_BOLT_BASE_DAMAGE = 30;
 
 export class BlackMage implements PlayerClass {
   private readonly direction = new Vector3();
@@ -142,10 +144,12 @@ export class BlackMage implements PlayerClass {
   }
 
   private createDarkBoltDefinition(): ClassAbilityDefinition {
+    const abilityId = "black-mage-dark-bolt";
     return {
-      id: "black-mage-dark-bolt",
+      id: abilityId,
       hotkey: 1,
       cooldown: DARK_BOLT_INSTANT_COOLDOWN,
+      baseDamage: DARK_BOLT_BASE_DAMAGE,
       execute: (context: PlayerClassContext) => {
         this.direction.copy(context.enemyPosition).sub(context.playerPosition);
         if (this.direction.lengthSq() === 0) {
@@ -156,7 +160,13 @@ export class BlackMage implements PlayerClass {
         this.origin.copy(context.playerPosition).addScaledVector(this.direction, 0.6);
 
         const velocity = this.direction.clone().multiplyScalar(DARK_BOLT_PROJECTILE_SPEED);
-        context.spawnProjectile(this.origin, velocity, { color: 0x111827 });
+        const tags: DamageTag[] = ["projectile", "magic"];
+        const damage = context.createDamageInstance({
+          abilityId,
+          baseDamage: DARK_BOLT_BASE_DAMAGE,
+          tags
+        });
+        context.spawnProjectile(this.origin, velocity, { color: 0x111827, damage });
       }
     };
   }

--- a/src/app/core/classes/playerClass.ts
+++ b/src/app/core/classes/playerClass.ts
@@ -1,9 +1,11 @@
 import type { Vector3 } from "three";
 import type { AbilityStatus, ClassGaugeState } from "@app/core/abilityHud";
+import type { DamageInstance, DamageResult, DamageSourceParams } from "@app/core/damage";
 
 export interface ProjectileSpawnOptions {
   scale?: number;
   color?: number;
+  damage?: DamageInstance;
 }
 
 export interface PlayerClassContext {
@@ -12,6 +14,8 @@ export interface PlayerClassContext {
   isPlayerMoving: boolean;
   spawnProjectile: (origin: Vector3, velocity: Vector3, options?: ProjectileSpawnOptions) => void;
   setCastProgress: (progress: number | null) => void;
+  createDamageInstance: (params: DamageSourceParams) => DamageInstance;
+  dealDamage: (instance: DamageInstance) => DamageResult;
 }
 
 export interface PlayerClass {

--- a/src/app/core/damage.ts
+++ b/src/app/core/damage.ts
@@ -1,0 +1,95 @@
+import type { ClassAbilityDefinition } from "@app/core/classes/abilities";
+
+export type DamageTag =
+  | "projectile"
+  | "melee"
+  | "empowered"
+  | "magic"
+  | "physical";
+
+export interface DamageSourceParams {
+  abilityId: ClassAbilityDefinition["id"];
+  baseDamage: number;
+  tags?: DamageTag[];
+}
+
+export interface DamageResult {
+  abilityId: ClassAbilityDefinition["id"];
+  baseDamage: number;
+  amount: number;
+  tags: readonly DamageTag[];
+}
+
+export interface DamageInstance {
+  abilityId: ClassAbilityDefinition["id"];
+  baseDamage: number;
+  readonly tags: readonly DamageTag[];
+  resolved: boolean;
+  resolve(): DamageResult;
+}
+
+export interface DamageModificationContext {
+  readonly abilityId: ClassAbilityDefinition["id"];
+  readonly baseDamage: number;
+  readonly tags: readonly DamageTag[];
+  amount: number;
+}
+
+export type DamageModifier = (context: DamageModificationContext) => void;
+
+export class DamageEngine {
+  private readonly modifiers: DamageModifier[] = [];
+
+  createInstance(params: DamageSourceParams): DamageInstance {
+    const tags = params.tags ? [...params.tags] : [];
+    let cached: DamageResult | null = null;
+
+    const instance: DamageInstance = {
+      abilityId: params.abilityId,
+      baseDamage: params.baseDamage,
+      tags,
+      resolved: false,
+      resolve: () => {
+        if (!cached) {
+          cached = this.evaluate(params.abilityId, params.baseDamage, tags);
+        }
+        instance.resolved = true;
+        return cached;
+      }
+    };
+
+    return instance;
+  }
+
+  resolve(instance: DamageInstance): DamageResult {
+    return instance.resolve();
+  }
+
+  registerModifier(modifier: DamageModifier) {
+    this.modifiers.push(modifier);
+  }
+
+  private evaluate(
+    abilityId: ClassAbilityDefinition["id"],
+    baseDamage: number,
+    tags: readonly DamageTag[]
+  ): DamageResult {
+    const context: DamageModificationContext = {
+      abilityId,
+      baseDamage,
+      amount: baseDamage,
+      tags
+    };
+
+    for (const modifier of this.modifiers) {
+      modifier(context);
+    }
+
+    return {
+      abilityId,
+      baseDamage,
+      amount: context.amount,
+      tags
+    };
+  }
+}

--- a/src/app/core/damageTracker.ts
+++ b/src/app/core/damageTracker.ts
@@ -1,0 +1,62 @@
+const TRACK_DURATION_SECONDS = 60;
+
+export interface DamageTrackerState {
+  totalDamage: number;
+  elapsed: number;
+  duration: number;
+  active: boolean;
+  locked: boolean;
+  dps: number;
+}
+
+export class DamageTracker {
+  private totalDamage = 0;
+  private elapsed = 0;
+  private active = false;
+  private locked = false;
+
+  update(deltaTime: number) {
+    if (!this.active || this.locked) {
+      return;
+    }
+
+    this.elapsed = Math.min(this.elapsed + deltaTime, TRACK_DURATION_SECONDS);
+    if (this.elapsed >= TRACK_DURATION_SECONDS) {
+      this.locked = true;
+    }
+  }
+
+  record(amount: number) {
+    if (this.locked) {
+      return;
+    }
+
+    if (!this.active) {
+      this.active = true;
+      this.elapsed = 0;
+    }
+
+    this.totalDamage += amount;
+  }
+
+  reset() {
+    this.totalDamage = 0;
+    this.elapsed = 0;
+    this.active = false;
+    this.locked = false;
+  }
+
+  getState(): DamageTrackerState {
+    const effectiveDuration = this.locked ? TRACK_DURATION_SECONDS : this.elapsed;
+    const dps = effectiveDuration > 0 ? this.totalDamage / effectiveDuration : 0;
+
+    return {
+      totalDamage: this.totalDamage,
+      elapsed: this.locked ? TRACK_DURATION_SECONDS : this.elapsed,
+      duration: TRACK_DURATION_SECONDS,
+      active: this.active,
+      locked: this.locked,
+      dps
+    };
+  }
+}

--- a/src/app/rendering/damageNumbers.ts
+++ b/src/app/rendering/damageNumbers.ts
@@ -1,0 +1,106 @@
+import { Vector3 } from "three";
+import type { OrthographicCamera, Vector2 } from "three";
+
+interface DamageNumberInstance {
+  element: HTMLDivElement;
+  basePosition: Vector3;
+  offset: Vector3;
+  elapsed: number;
+  lifetime: number;
+  amount: number;
+}
+
+const DEFAULT_LIFETIME = 0.9;
+const VERTICAL_SCREEN_LIFT = 36;
+
+export class DamageNumberManager {
+  private readonly container: HTMLDivElement;
+  private readonly numbers: DamageNumberInstance[] = [];
+  private readonly scratch = new Vector3();
+
+  constructor(
+    private readonly host: HTMLElement,
+    private readonly camera: OrthographicCamera,
+    private readonly viewport: Vector2
+  ) {
+    this.container = document.createElement("div");
+    this.container.style.position = "absolute";
+    this.container.style.left = "0";
+    this.container.style.top = "0";
+    this.container.style.width = "100%";
+    this.container.style.height = "100%";
+    this.container.style.pointerEvents = "none";
+    this.container.style.zIndex = "90";
+    this.container.style.overflow = "hidden";
+    this.host.appendChild(this.container);
+  }
+
+  spawn(amount: number, worldPosition: Vector3) {
+    const element = document.createElement("div");
+    element.style.position = "absolute";
+    element.style.transform = "translate(-50%, -50%)";
+    element.style.fontWeight = "700";
+    element.style.fontSize = "18px";
+    element.style.color = "#fbbf24";
+    element.style.textShadow = "0 1px 2px rgba(15, 23, 42, 0.65)";
+    element.style.pointerEvents = "none";
+    element.style.transition = "opacity 0.1s linear";
+    element.style.willChange = "transform, opacity";
+    element.textContent = this.formatAmount(amount);
+    this.container.appendChild(element);
+
+    const offset = new Vector3((Math.random() - 0.5) * 0.6, 0, (Math.random() - 0.5) * 0.6);
+
+    this.numbers.push({
+      element,
+      basePosition: worldPosition.clone(),
+      offset,
+      elapsed: 0,
+      lifetime: DEFAULT_LIFETIME,
+      amount
+    });
+
+    this.update(0);
+  }
+
+  update(deltaTime: number) {
+    for (let i = this.numbers.length - 1; i >= 0; i -= 1) {
+      const instance = this.numbers[i];
+      instance.elapsed += deltaTime;
+      const progress = instance.elapsed / instance.lifetime;
+
+      if (progress >= 1) {
+        this.container.removeChild(instance.element);
+        this.numbers.splice(i, 1);
+        continue;
+      }
+
+      this.scratch.copy(instance.basePosition);
+      this.scratch.add(instance.offset);
+      this.scratch.y = 1.2;
+      this.scratch.project(this.camera);
+
+      const x = (this.scratch.x * 0.5 + 0.5) * this.viewport.x;
+      const y = (1 - (this.scratch.y * 0.5 + 0.5)) * this.viewport.y - progress * VERTICAL_SCREEN_LIFT;
+
+      instance.element.style.opacity = (1 - progress).toFixed(2);
+      instance.element.style.transform = `translate(-50%, -50%) translate(${x}px, ${y}px)`;
+    }
+  }
+
+  clear() {
+    for (const instance of this.numbers) {
+      this.container.removeChild(instance.element);
+    }
+    this.numbers.length = 0;
+  }
+
+  dispose() {
+    this.clear();
+    this.host.removeChild(this.container);
+  }
+
+  private formatAmount(amount: number) {
+    return Number.isInteger(amount) ? amount.toString() : amount.toFixed(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable damage engine with real-time tracking and floating damage numbers
- hook marksman and black mage projectiles into the damage pipeline with base damage values
- surface a damage-per-second tracker with reset controls in the debug overlay

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e487cfc2dc8325a8432df19de2b220